### PR TITLE
Let the download link follow the latest release

### DIFF
--- a/windows.html
+++ b/windows.html
@@ -10,15 +10,8 @@ title: Windows
 			<h3>最新版本</h3>
 			<ul>
 				<li>
-					<a href="https://github.com/pcman-bbs/pcman-windows/releases/download/9.4.2/PCMan.exe">
-						<span class="pcman">PCMan Lite</span>
-						<span class="version">Novus Ver. 9.4.2</span>
-					</a>
-				</li>
-				<li>
-					<a href="https://github.com/pcman-bbs/pcman-windows/releases/download/9.4.2/PCManCB.exe">
-						<span class="pcman">PCMan Combo</span>
-						<span class="version">Novus Ver. 9.4.2</span>
+					<a href="https://github.com/pcman-bbs/pcman-windows/releases">
+						<span class="">請至 GitHub 下載區取得</span>
 					</a>
 				</li>
 			</ul>


### PR DESCRIPTION
The origin link (ver.9.4.2) is not the latest release version.